### PR TITLE
add export as spans

### DIFF
--- a/app/server/management/commands/autolabel.py
+++ b/app/server/management/commands/autolabel.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand, CommandError
 from server.models import (Document, Project, Label,
                           SequenceAnnotation, User)
 import string
+import json
 
 # if we want to add new labels, decide on some new colors for them
 SOME_COLORS_TO_CHOOSE_FROM = ["#001f3f", "#0074D9", "#7FDBFF",


### PR DESCRIPTION
This is a minimal way to export-as-spans. Doesn't currently have a button/front-end option to hit the endpoint, but can be either hit manually or we could refactor/redesign the export functionality.

This can probably be reused in feature/auto_labeling AutoLabeling.put() function